### PR TITLE
Feature: Allow external async calls into strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The internal architecture primarily consists of one big stream and a bunch of co
 -   [x] Simple API
 -   [x] Thoroughly tested
 -   [x] Typescript definitions
+-   [x] Allow async calls into strategy
 
 ## Installation
 
@@ -38,7 +39,7 @@ const feeds = {
   myStreamFeed: fs.createReadStream(...)
 }
 
-const strategy = (context, action) => {
+const strategy = (context, action, next) => {
 
   // Place an order
   if (action.type === 'myQuandlFeed') {
@@ -58,6 +59,9 @@ const strategy = (context, action) => {
       id: 123
     })
   }
+
+  // Will call strategy with next data
+  next(action);
 }
 
 // Create the trading stream
@@ -143,7 +147,7 @@ The `createTrader`-function returns an unconsumed stream, and so it is up to you
 
 ```javascript
 const settings = {...}
-const strategy = (context, action) => {...}
+const strategy = (context, action ,next) => {...}
 
 createTrader(settings, strategy).resume()
 ```
@@ -154,7 +158,7 @@ However, you could also do crazy things like this:
 import { createTrader, ORDER_FILLED, ORDER_FAILED } from 'devalpha'
 
 const settings = {...}
-const strategy = (context, action) => {...}
+const strategy = (context, action, next) => {...}
 
 const stream = createTrader(settings, strategy)
 

--- a/__tests__/createStrategy.spec.ts
+++ b/__tests__/createStrategy.spec.ts
@@ -17,13 +17,6 @@ beforeEach(() => {
   t.context.middleware = createMiddleware(() => {})(store)(next)
 })
 
-test("pass the intercepted action to the next", () => {
-  const { middleware, next } = t.context
-  const action = { type: "FOO", payload: {} }
-  middleware(action)
-  expect(next.mock.calls[0][0]).toBe(action)
-})
-
 test("order() should synchronously dispatch order requested", done => {
   const { store, next } = t.context
   const action = { type: "FOO", payload: { timestamp: 0 } }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -76,7 +76,8 @@ export function createTrader(settings: any, strategy: Strategy) {
   }
 
   if (config.dashboard.active && config.project === null) {
-    throw new Error('the dashboard will not recognize your algorithm unless you set config.project to the ID of your DevAlpha project');
+    // tslint:disable:max-line-length
+    throw new Error('the dashboard will not recognize your algorithm unless you set config.project to the ID of your DevAlpha project')
   }
 
   // Store
@@ -200,10 +201,10 @@ export function createTrader(settings: any, strategy: Strategy) {
     const socketStream = output.fork()
     output = output.fork()
 
-    let id = 0;
+    let id = 0
     const createMessage = (message: any) => {
       let response = ''
-      response += `id: ${id++}\n`
+      response += `id: ${id+=1}\n`
       response += `event: ${message.type}\n`
       response += `data: ${JSON.stringify(message.payload)}\n`
       response += `\n`

--- a/lib/middleware/createStrategy.ts
+++ b/lib/middleware/createStrategy.ts
@@ -40,9 +40,9 @@ export function createStrategy(strategy: Strategy): Middleware {
           }
         })
       },
-      action
+      action,
+      next
     )
-    return next(action)
   }
 
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -133,4 +133,4 @@ export interface ExecutedOrder extends CreatedOrder {
   id: string
 }
 
-export type Strategy = (context: Context, action: StreamAction) => void
+export type Strategy = (context: Context, action: StreamAction, next: Function) => void


### PR DESCRIPTION
This Pull Request allows developers to use external async calls into "strategy".
This feature is useful every time you need to get external async informations (external signals) when "strategy" has been called.
After you get your async informations you can trigger "next(action)" from strategy